### PR TITLE
Remove probes with empty gene names

### DIFF
--- a/app/scripts/SinkhornNNLSLinseedC.R
+++ b/app/scripts/SinkhornNNLSLinseedC.R
@@ -273,7 +273,8 @@ SinkhornNNLSLinseed <- R6Class(
       
       if (annotate) {
         probes <- setNames(as.character(fdata[, 1]), rownames(fdata))
-        
+        probes <- probes[!(is.na(probes) | probes=="")]
+
         geneToProbes <- lapply(split(probes, probes), names)
         
         bestProbes <- sapply(geneToProbes, function(probes) {


### PR DESCRIPTION
### Description

This code fixes error when we had error after data annotation.

### Motivation
Bug fix for issue #4

### Changes
Just filter empty rows while mapping probe to gene
