### PR TITLE
Reverse sinkhorn

### DIFF
--- a/app/scripts/SinkhornNNLSLinseedC.R
+++ b/app/scripts/SinkhornNNLSLinseedC.R
@@ -73,8 +73,12 @@ SinkhornNNLSLinseed <- R6Class(
     D_h = NULL,
     D_w = NULL,
     D = NULL,
-    D_v_row = NULL,
-    D_v_column = NULL,
+    D_vs_row = NULL,
+    D_vs_col = NULL,
+    D_ws_col = NULL,
+    D_hs_row = NULL,
+    W_column = NULL,
+    H_column = NULL,
 
     init_D_w = NULL,
     init_D_h = NULL,
@@ -395,7 +399,32 @@ SinkhornNNLSLinseed <- R6Class(
       self$V_column <- scaled$V_column
       rownames(self$V_column) <- rownames(self$filtered_dataset)
       colnames(self$V_column) <- colnames(self$filtered_dataset)
+
+      self$D_vs_row <- scaled$D_vs_row
+      self$D_vs_col <- scaled$D_vs_col
+
     },
+
+    traceBackScaling = function(iterations = 20){
+        #' Calculate all normalizing matrices and restore "unscaled" W and H
+        #'
+        #' columns of D_ws_col and D_hs_row  will contain history of D_w and D_h matrices
+        #' W_column, H_column will contain "unscaled" W and H
+
+        result_W_col = t(self$S) %*% self$Omega
+        result_H_row = self$X %*% self$R
+
+        unscaled <- traceBackScaling(result_H_row, result_W_col, self$D_vs_row, self$D_vs_col, iterations)
+        self$D_ws_col <- unscaled$D_ws_col
+        self$D_hs_row <- unscaled$D_hs_row
+        self$W_column <- unscaled$W_columssn
+        self$H_column <- unscaled$H_column
+
+        rownames(self$W_column) <- rownames(self$filtered_dataset)
+        colnames(self$H_column) <- colnames(self$filtered_dataset)
+
+    },
+
     
     getSvdProjectionsNew = function(k = self$cell_types){
       svd_ <- svd(self$V_row)

--- a/app/scripts/SinkhornNNLSLinseedC.R
+++ b/app/scripts/SinkhornNNLSLinseedC.R
@@ -417,7 +417,7 @@ SinkhornNNLSLinseed <- R6Class(
         unscaled <- traceBackScaling(result_H_row, result_W_col, self$D_vs_row, self$D_vs_col, iterations)
         self$D_ws_col <- unscaled$D_ws_col
         self$D_hs_row <- unscaled$D_hs_row
-        self$W_column <- unscaled$W_columssn
+        self$W_column <- unscaled$W_column
         self$H_column <- unscaled$H_column
 
         rownames(self$W_column) <- rownames(self$filtered_dataset)

--- a/app/scripts/pipeline.cpp
+++ b/app/scripts/pipeline.cpp
@@ -8,15 +8,28 @@ using namespace std;
 
 // [[Rcpp::export]]
 List scaleDataset(const arma::mat& V, int iterations) {
+  arma::mat D_vs_row(V.n_rows, iterations);
+  arma::mat D_vs_col(V.n_cols, iterations);
+
   arma::mat V_row = V;
   arma::mat V_column = V;
-  for (int i=0; i<=iterations; i++){
-    V_row = diagmat(1/arma::sum(V_column,1)) * V_column;
-    V_column = V_row * diagmat(1/arma::sum(V_row,0));
+  for (int i=0; i<iterations; i++){
+    arma::mat D_v1 = 1/arma::sum(V_column,1);
+    D_vs_row.col(i) = D_v1;
+    V_row = diagmat(D_v1) * V_column;
+    arma::mat D_v2 = 1/arma::sum(V_row,0).t();
+    D_vs_col.col(i) = D_v2;
+    V_column = V_row * diagmat(D_v2);
   }
   return List::create(Named("V_row") = V_row,
-                      Named("V_column") = V_column);
+                      Named("V_column") = V_column,
+                      Named("D_vs_row") = D_vs_row,
+                      Named("D_vs_col") = D_vs_col);
 }
+
+
+
+
 // [[Rcpp::export]]
 arma::mat getDoubleProjection(const arma::mat& V, const arma::mat& R, const arma::mat& S) {
   arma::mat T = S.t() * S * V * R.t() * R;
@@ -129,6 +142,56 @@ arma::mat nnls_C__(mat A, mat b, int max_iter = 500, double tol = 1e-6)
   
   return x;
 }
+
+// [[Rcpp::export]]
+List traceBackScaling(const arma::mat& result_H_row,
+                         const arma::mat& result_W_col ,
+                         const arma::mat& D_vs_row,
+                         const arma::mat& D_vs_col,
+                         int iterations) {
+
+    arma::mat H_row = result_H_row;
+    arma::mat W_col = result_W_col;
+    arma::mat H_col;
+    arma::mat W_row;
+
+    arma::mat D_ws_col(W_col.n_cols, iterations); // should be K*iterations
+    arma::mat D_hs_row(H_row.n_rows, iterations); // should be K*iterations
+
+    //arma::mat D_ws_col(V.n_cols, iterations);
+
+    arma::mat ones_like_W(W_col.n_rows, 1, arma::fill::ones); // M*1
+    arma::mat ones_like_H(H_row.n_cols, 1, arma::fill::ones); // N*1
+
+    arma::vec D_w_inv_pred_vec(W_col.n_cols, arma::fill::zeros);
+    arma::vec D_h_inv_pred_vec(H_row.n_rows, arma::fill::zeros);
+
+
+
+    D_w_inv_pred_vec = nnls_C__(W_col, ones_like_W);
+    W_row = W_col * diagmat(D_w_inv_pred_vec);
+
+    for (int i=iterations-1; i>=0; i--){
+        D_h_inv_pred_vec = nnls_C__(H_row.t(), ones_like_H);
+
+        D_ws_col.col(i) = 1/D_w_inv_pred_vec;
+        D_hs_row.col(i) = 1/D_h_inv_pred_vec;
+        H_col = diagmat(D_h_inv_pred_vec) * H_row;
+        W_col = diagmat(1/D_vs_row.col(i)) * W_row * diagmat(1/D_h_inv_pred_vec);
+
+        if (i != 0) {
+            D_w_inv_pred_vec = nnls_C__(W_col, ones_like_W);
+            W_row = W_col * diagmat(D_w_inv_pred_vec);
+            H_row = diagmat(1/D_w_inv_pred_vec) * H_col * diagmat(1/D_vs_col.col(i-1));
+        }
+    }
+
+  return List::create(Named("W_column") = W_col,
+                      Named("H_column") = H_col,
+                      Named("D_ws_col") = D_ws_col,
+                      Named("D_hs_row") = D_hs_row);
+}
+
 
 
 // [[Rcpp::export]]


### PR DESCRIPTION
This code adds functionality to c++

We now have "reverse sinkhorn" method.
It helps to get  "unscaled" W and H from scaled ones.
We now store all D_v, D_h, D_w matrices for each step.

![image](https://github.com/aladyeva-wustl/docker_linseed_snakemake/assets/19429157/1093f2d4-b5eb-4fd0-9980-9d0e86a013f2)

![image](https://github.com/aladyeva-wustl/docker_linseed_snakemake/assets/19429157/b79c8745-de2b-4094-b0a8-48e72c12e069)

